### PR TITLE
Qualcomm RB3 README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ After you push, the FoundriesFactory will build a new target. Once built, any re
 Once connected to the network you can log in over ssh if desired:
 
 ```bash
-ssh fio@qcm6490.local
+ssh fio@qcs6490-rb3gen2-vision-kit.local
 ```
 
 OR

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Password: `fio`
 ### Register Your Device
 
 Register your device with FoundriesFactory:
-`https://docs.foundries.io/latest/getting-started/register-device/index.html`
+https://docs.foundries.io/latest/getting-started/register-device/index.html
 
 ---
 
@@ -212,7 +212,7 @@ The built targets can be found here:
 
 Compose apps fill the gap for Factory devices in distributing applications.
 
-- To build your own compose applications, refer to `https://docs.foundries.io/latest/reference-manual/docker/compose-apps.html`
+- To build your own compose applications, refer to https://docs.foundries.io/latest/reference-manual/docker/compose-apps.html
 - Your factory has some sample compose applications ready to deploy.
 
 ### Qualcomm® AI Hub


### PR DESCRIPTION
A couple of trivial fixes to the Qualcomm RB3 README:

- fix default hostname of Vision Kit
- fix a couple of links that don't need to be quoted