### PR TITLE
QCOM boot binaries implicit signing

### DIFF
--- a/recipes-firmware/firmware/firmware-qcom-bootbins_1.0.bbappend
+++ b/recipes-firmware/firmware/firmware-qcom-bootbins_1.0.bbappend
@@ -1,5 +1,7 @@
 PROVIDES += "virtual/bootloader"
 
+include qcom-firmware-sign.inc
+
 # doesn't have GNU_HASH (didn't pass LDFLAGS?)
 INSANE_SKIP:${PN} += "ldflags textrel"
 
@@ -27,3 +29,21 @@ SRC_URI[rb8-core-kit.sha256sum] = "a252244f800d7c9e15883e12935af4113f9f2ecba6490
 do_deploy:append() {
 	find "${WORKDIR}" -maxdepth 1 -name 'cdt*bin' -exec install -m 0644 {} ${DEPLOYDIR} \;
 }
+
+do_qcom_firmware_sign() {
+    if ! qcom_check_signing_enabled ; then
+        return 0
+    fi
+
+    bbnote "Searching for MBN and ELF files to sign"
+    # firmware_install, defined in the firmware-common.unc unpacks archieve with firmware binaries
+    # directly to ${D}, so we should look into this directory
+    file_list=$(find "${D}/" -maxdepth 1 -type f \( -iname "*.mbn" -o -iname "*.elf" \))
+    for file in ${file_list}; do
+        if ! qcom_sign_verify_file "${file}" ; then
+            bbfatal "Failed to sign file: ${file}"
+        fi
+    done
+}
+
+addtask do_qcom_firmware_sign before do_deploy after do_install

--- a/recipes-firmware/firmware/firmware-qcom-hlosfw_1.0.bbappend
+++ b/recipes-firmware/firmware/firmware-qcom-hlosfw_1.0.bbappend
@@ -1,0 +1,19 @@
+include qcom-firmware-sign.inc
+
+do_qcom_firmware_sign() {
+    if ! qcom_check_signing_enabled ; then
+        return 0
+    fi
+
+    bbnote "Searching for MBN and ELF files to sign"
+    # firmware_install, defined in the firmware-common.unc unpacks archieve with firmware binaries
+    # directly to ${D}, so we should look into this directory
+    file_list=$(find "${D}/" -type f \( -iname "*.mbn" -o -iname "*.elf" \))
+    for file in ${file_list}; do
+        if ! qcom_sign_verify_file "${file}" ; then
+            bbfatal "Failed to sign file: ${file}"
+        fi
+    done
+}
+
+addtask do_qcom_firmware_sign before do_deploy after do_install

--- a/recipes-firmware/firmware/qcom-firmware-sign.inc
+++ b/recipes-firmware/firmware/qcom-firmware-sign.inc
@@ -1,0 +1,107 @@
+qcom_sign_verify_file() {
+	file="$(basename $1)"
+	filedir="$(dirname "$1")"
+	sectools="${QCOM_FIRMWARE_SIGN_SECTOOLS_DIR}/sectools"
+	secprofile="${QCOM_FIRMWARE_SIGN_SECPROFILE}"
+	root_hash="0x$(cat ${QCOM_FIRMWARE_SIGN_KEY_DIR}/sha384_roots_hash.txt | cut -d' ' -f2)"
+
+	newline="\n"
+
+	image_id_mapping="\
+		a660_zap.mbn GPU-MICRO-CODE ${newline}\
+		adsp.mbn ADSP ${newline}\
+		aop.mbn AOP ${newline}\
+		cdsp.mbn CDSP ${newline}\
+		cpucp.elf CPUCP ${newline}\
+		devcfg.mbn TZ-DEVCFG ${newline}\
+		hypvm.mbn QHEE ${newline}\
+		imagefv.elf UEFIFV ${newline}\
+		ipa_fws.mbn IPA-FW ${newline}\
+		loadalgota64.mbn TZ-APP-OEM ${newline}\
+		msbtfw11.mbn SKIP ${newline}\
+		multi_image.mbn OEM-MISC ${newline}\
+		prog_firehose_ddr.elf DEVICE-PROGRAMMER ${newline}\
+		prog_firehose_lite.elf DEVICE-PROGRAMMER ${newline}\
+		qupv3fw.elf QUPV3 ${newline}\
+		sec.elf SEC-ELF ${newline}\
+		shrm.elf SHRM ${newline}\
+		tz.mbn TZ ${newline}\
+		uefi.elf UEFI ${newline}\
+		uefi_sec.mbn TZ-APP-OEM ${newline}\
+		vpu20_1v.mbn VENUS-FW ${newline}\
+		vpu30_4v.mbn VENUS-FW ${newline}\
+		vpu30_4v_16mb.mbn VENUS-FW ${newline}\
+		wpss.mbn WPSS ${newline}\
+		xbl_config.elf XBL-CONFIG ${newline}\
+		xbl_config_gunyah.elf XBL-CONFIG ${newline}\
+		xbl_config_kvm.elf XBL-CONFIG ${newline}\
+		xbl.elf XBL ${newline}\
+		XblRamdump.elf XBL-RAM-DUMP ${newline}\
+		DigestsToSign.bin.mbn VIP ${newline}\
+		FD02C9DA-306C-48C7-A49C-BBD827AE86EE.mbn TZ-APP-OEM ${newline}\
+	"
+
+	sign_id=$(${sectools} secure-image --inspect $1 | grep "| Software ID:" | cut -d'|' -f3)
+	if [ -z "${sign_id}" ]; then
+		bbwarn "$file does not contain signatures, skipping"
+		return 0
+	fi
+
+	# Lookup the IMAGE-ID from mapping
+	image_id=$(echo "${image_id_mapping}" | grep "${file}" | cut -d' ' -f2)
+	bbdebug 1 "IMAGE_ID = ${image_id}"
+	if [ -z "${image_id}" ] || [ "${image_id}" = "UNKNOWN" ]; then
+		bbfatal "Unable to find IMAGE-ID mapping for ${file}"
+	fi
+
+	if [ "${image_id}" = "SKIP" ]; then
+		bbwarn "Skip signing of ${file}"
+		return 0
+	fi
+
+	${sectools} secure-image \
+		--sign $1 --image-id=${image_id} \
+		--security-profile ${secprofile} \
+		--anti-rollback-version=0x0 \
+		--signing-mode LOCAL \
+		--root-certificate-index 0 \
+		--root-certificate=${QCOM_FIRMWARE_SIGN_KEY_DIR}/qpsa_rootca0.cer \
+		--ca-certificate=${QCOM_FIRMWARE_SIGN_KEY_DIR}/qpsa_attestca0.cer \
+		--ca-key=${QCOM_FIRMWARE_SIGN_KEY_DIR}/qpsa_attestca0.key \
+		--outfile $1
+	if [ $? -ne 0 ]; then
+		bbfatal "Signing ${file} failed"
+	fi
+
+	bbnote "Verifying root hash of ${file}"
+	${sectools} secure-image --verify-root ${root_hash} $1
+	if [ $? -ne 0 ]; then
+		bbfatal "Root hash of ${file} failed verification"
+	fi
+}
+
+QCOM_FIRMWARE_SIGN_ENABLE ??= "0"
+
+qcom_check_signing_enabled() {
+	if [ "${QCOM_FIRMWARE_SIGN_ENABLE}" != "1" ]; then
+		return 0
+	fi
+
+	if [ ! -f "${QCOM_FIRMWARE_SIGN_KEY_DIR}/qpsa_rootca0.cer" ]; then
+		bbfatal "QCOM_FIRMWARE_SIGN_KEY_DIR or Root certificate is invalid"
+	fi
+	if [ ! -f "${QCOM_FIRMWARE_SIGN_KEY_DIR}/qpsa_attestca0.cer" ]; then
+		bbfatal "QCOM_FIRMWARE_SIGN_KEY_DIR or CA certificate is invalid"
+	fi
+	if [ ! -f "${QCOM_FIRMWARE_SIGN_KEY_DIR}/qpsa_attestca0.key" ]; then
+		bbfatal "QCOM_FIRMWARE_SIGN_KEY_DIR or CA key is invalid"
+	fi
+	if [ ! -f "${QCOM_FIRMWARE_SIGN_SECTOOLS_DIR}/sectools" ]; then
+		bbfatal "QCOM_FIRMWARE_SIGN_SECTOOLS_DIR is invalid"
+	fi
+	if [ ! -f "${QCOM_FIRMWARE_SIGN_SECPROFILE}" ]; then
+		bbfatal "QCOM_FIRMWARE_SIGN_SECPROFILE is invalid"
+	fi
+}
+
+do_qcom_firmware_sign[vardeps] += "QCOM_FIRMWARE_SIGN_ENABLE QCOM_FIRMWARE_SIGN_KEY_DIR QCOM_FIRMWARE_SIGN_SECPROFILE"

--- a/recipes-firmware/firmware/qcom-video-firmware_%.bbappend
+++ b/recipes-firmware/firmware/qcom-video-firmware_%.bbappend
@@ -1,0 +1,17 @@
+include qcom-firmware-sign.inc
+
+do_qcom_firmware_sign() {
+    if ! qcom_check_signing_enabled ; then
+        return 0
+    fi
+
+    bbnote "Searching for MBN and ELF files to sign"
+    file_list=$(find "${S}/" -type f \( -iname "*.mbn" -o -iname "*.elf" \))
+    for file in ${file_list}; do
+        if ! qcom_sign_verify_file "${file}" ; then
+            bbfatal "Failed to sign file: ${file}"
+        fi
+    done
+}
+
+addtask do_qcom_firmware_sign before do_install after do_compile


### PR DESCRIPTION
Add signing of pre-built boot firmware binaries. This signing is done using pre-installed SecTools V2 package.

These variables should be defined to enable this feature: 
`QCOM_FIRMWARE_SIGN_ENABLE` - should be "1"
`QCOM_FIRMWARE_SIGN_KEY_DIR` - path to ecdsa/rsa keys and certificates
`QCOM_FIRMWARE_SIGN_SECTOOLS_DIR` - path to sectools package
`QCOM_FIRMWARE_SIGN_SECPROFILE` - path to security profile for your SoC